### PR TITLE
upgrade to Sjsonnet 0.4.9 (was 0.4.0)

### DIFF
--- a/examples/default-task/build.gradle.kts
+++ b/examples/default-task/build.gradle.kts
@@ -47,9 +47,9 @@ repositories {
 }
 
 dependencies {
-    implementation("org.scala-lang:scala-library:2.13.10")
-    testImplementation("org.scalatest:scalatest_2.13:3.2.9")
-    testImplementation(platform("org.junit:junit-bom:5.7.2"))
+    implementation("org.scala-lang:scala-library:2.13.12")
+    testImplementation("org.scalatest:scalatest_2.13:3.2.17")
+    testImplementation(platform("org.junit:junit-bom:5.10.1"))
     testImplementation("org.junit.jupiter:junit-jupiter")
 }
 

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     scala
     `java-gradle-plugin`
     `maven-publish`
-    id("com.gradle.plugin-publish") version "1.2.0"
+    id("com.gradle.plugin-publish") version "1.2.1"
 }
 
 group = "io.github.chklauser.sjsonnet"
@@ -13,16 +13,16 @@ repositories {
 }
 
 dependencies {
-    implementation("org.scala-lang:scala-library:2.13.10")
-    implementation("com.databricks:sjsonnet_2.13:0.4.0")
-    testImplementation("org.scalatest:scalatest_2.13:3.2.9")
-    testImplementation(platform("org.junit:junit-bom:5.7.2"))
+    implementation("org.scala-lang:scala-library:2.13.12")
+    implementation("com.databricks:sjsonnet_2.13:0.4.9")
+    testImplementation("org.scalatest:scalatest_2.13:3.2.17")
+    testImplementation(platform("org.junit:junit-bom:5.10.1"))
     testImplementation("org.junit.jupiter:junit-jupiter")
     constraints {
         implementation("org.apache.logging.log4j:log4j-core") {
             version {
                 strictly("[2.17, 3[")
-                prefer("2.17.1")
+                prefer("2.22.1")
             }
             because("CVE-2021-44228, CVE-2021-45046, CVE-2021-45105: Log4j vulnerable to remote code execution and other critical security vulnerabilities")
         }

--- a/plugin/settings.gradle.kts
+++ b/plugin/settings.gradle.kts
@@ -11,7 +11,7 @@ pluginManagement {
 }
 
 plugins {
-    id("org.ajoberstar.reckon.settings") version "0.18.0"
+    id("org.ajoberstar.reckon.settings") version "0.18.2"
 }
 
 extensions.configure<org.ajoberstar.reckon.gradle.ReckonExtension> {

--- a/plugin/src/main/scala/io/github/chklauser/sjsonnet/gradle/SjsonnetPlugin.scala
+++ b/plugin/src/main/scala/io/github/chklauser/sjsonnet/gradle/SjsonnetPlugin.scala
@@ -12,6 +12,8 @@ import sjsonnet.{Expr, FileScope, Path, SjsonnetMain}
 import java.util.concurrent.atomic.AtomicBoolean
 import scala.collection.mutable
 import internal.implicits._
+import sjsonnet.DefaultParseCache
+import sjsonnet.ParseCache
 
 class SjsonnetPlugin extends Plugin[Project] {
   private[this] var sourceSetRegistered = new AtomicBoolean(false)
@@ -84,6 +86,6 @@ class SjsonnetPlugin extends Plugin[Project] {
 }
 
 object SjsonnetPlugin {
-  val parseCache: ThreadLocal[mutable.HashMap[(Path, String), Parsed[(Expr, FileScope)]]] =
-    ThreadLocal.withInitial(() => SjsonnetMain.createParseCache())
+  val parseCache: ThreadLocal[ParseCache] =
+    ThreadLocal.withInitial(() => new DefaultParseCache())
 }


### PR DESCRIPTION
There were some breaking changes:
1. replace `SjsonnetMain.createParseCache` with `DefaultParseCache`
2. external Maps are now passed as JSON-encoded strings (not `ujson.Value`s). We use `ujson.write`, mimicking what SjsonnetMain does.
3. the resolver is now a `Importer` trait

Also upgrades
 - scala library from 2.13.10 to 2.13.12
 - scalatest from 3.2.9 to 3.2.17
 - junit from 5.7.2 to 5.10.1
 - log4j from 2.17.1 to 2.22.1