### PR TITLE
Add support for more sjsonnet settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,40 @@ tasks {
 If you use `import` or `importstr`, the same considerations as for the "custom specifications"
 approach apply.
 
+### Settings
+The plugin supports a subset of the settings of sjsonnet. 
+See [Config.scala](https://github.com/databricks/sjsonnet/blob/9534260fff4a50d29db379e307bce9a484790fa7/sjsonnet/src-jvm-native/sjsonnet/Config.scala)
+for the documentation of those settings.
+
+All settings below are also available on the `SjsonnetTask`.
+
+```kotlin
+// build.gradle.kts (Kotlin Script Syntax)
+
+sjsonnet {
+  create("main") {
+    // Sjsonnet settings
+    indent.set(2)
+    preserveOrder.set(true)
+    strict.set(true)
+    noStaticErrors.set(true)
+    noDuplicateKeysInComprehension.set(true)
+    strictImportSyntax.set(true)
+    strictInheritedAssertions.set(true)
+    topLevelArguments.put("a1", 2)
+    externalVariables.put("e1", 1)
+
+    // Gradle plugin settings
+    // `searchPath` is the list of directories to search for imported files 
+    searchPath.from(...)
+    // If `imports` is set, then it serves as an allow-list for imports (only files in the list can be imported)
+    // This is useful because the plugin needs to list dependencies for up-to-date checking. Un-declared imported
+    // files can lead to unpredictable result.
+    imports.from(...)
+  }
+}
+```
+
 ## FAQ
 ### Why write a Gradle plugin in scala?
 The `s` in `sjsonnet` stands for "Scala". Its API is not straightforward to

--- a/examples/default-task/build.gradle.kts
+++ b/examples/default-task/build.gradle.kts
@@ -29,6 +29,14 @@ sjsonnet {
         indent.set(4)
         sources.from(project.layout.projectDirectory.dir("custom-src"))
         // no need to specify additional inputs because each *.jsonnet file is self-contained
+
+        // custom settings (they all default to false)
+        preserveOrder.set(true)
+        strict.set(true)
+        noStaticErrors.set(true)
+        noDuplicateKeysInComprehension.set(true)
+        strictImportSyntax.set(true)
+        strictInheritedAssertions.set(true)
     }
 
     create("main") {

--- a/examples/default-task/custom-src/subdirectory/f4.jsonnet
+++ b/examples/default-task/custom-src/subdirectory/f4.jsonnet
@@ -3,6 +3,7 @@
 {
   'Vodka Martini': 'yes, please',
   Manhattan: {
+    // Order of keys should be preserved
     ingredients: [
       { kind: 'Rye', qty: 2.5 },
       { kind: 'Sweet Red Vermouth', qty: 1 },

--- a/examples/default-task/src/test/scala/VerifyGeneratedOutputIntTest.scala
+++ b/examples/default-task/src/test/scala/VerifyGeneratedOutputIntTest.scala
@@ -19,6 +19,17 @@ class VerifyGeneratedOutputIntTest extends Assertions {
   }
 
   @Test
+  def customPreservesOrder(): Unit = {
+    val path = basePath.resolve("custom").resolve("jsonnet/subdirectory/f4.json")
+    val content = Files.readString(path, StandardCharsets.UTF_8)
+
+    val i1 = content.indexOf("ingredients")
+    val i2 = content.indexOf("garnish")
+    val i3 = content.indexOf("served")
+    assert(Seq(i1, i2, i3).sorted == Seq(i1, i2, i3))
+  }
+
+  @Test
   def main(): Unit = {
     assertTwoFileStructure("main", 5, Seq("Champagne Essence"))
   }

--- a/plugin/src/main/scala/io/github/chklauser/sjsonnet/gradle/SjsonnetPlugin.scala
+++ b/plugin/src/main/scala/io/github/chklauser/sjsonnet/gradle/SjsonnetPlugin.scala
@@ -35,6 +35,12 @@ class SjsonnetPlugin extends Plugin[Project] {
           t.externalVariables.convention(s.externalVariables)
           t.topLevelArguments.convention(s.topLevelArguments)
           t.indent.convention(s.indent)
+          t.preserveOrder.convention(s.preserveOrder)
+          t.strict.convention(s.strict)
+          t.noStaticErrors.convention(s.noStaticErrors)
+          t.noDuplicateKeysInComprehension.convention(s.noDuplicateKeysInComprehension)
+          t.strictImportSyntax.convention(s.strictImportSyntax)
+          t.strictInheritedAssertions.convention(s.strictInheritedAssertions)
         }): Action[SjsonnetTask])
       aggregate.configure(t => t.dependsOn(generate))
 

--- a/plugin/src/main/scala/io/github/chklauser/sjsonnet/gradle/SjsonnetSpec.scala
+++ b/plugin/src/main/scala/io/github/chklauser/sjsonnet/gradle/SjsonnetSpec.scala
@@ -10,7 +10,7 @@ import scala.annotation.meta.beanGetter
 import scala.beans.BeanProperty
 import scala.jdk.CollectionConverters._
 
-//noinspection UnstableApiUsage
+//noinspection UnstableApiUsage,DuplicatedCode
 class SjsonnetSpec(@BeanProperty val name : String, project: Project) {
   if(name == null || name.isEmpty) {
     throw new GradleException("Name of sjsonnet spec cannot be null or empty.")
@@ -19,38 +19,49 @@ class SjsonnetSpec(@BeanProperty val name : String, project: Project) {
   @BeanProperty
   val namePascalCase: String = s"${name.charAt(0).toUpper}${name.substring(1)}"
 
-  //noinspection DuplicatedCode
   @BeanProperty
   val outputDirectory: DirectoryProperty = project.getObjects.directoryProperty()
   outputDirectory.convention(project.getLayout.getBuildDirectory.dir(s"generated/resources/$name/jsonnet"))
 
-  //noinspection DuplicatedCode
   @BeanProperty
   val sources: ConfigurableFileCollection = project.getObjects.fileCollection()
 
-  //noinspection DuplicatedCode
   @BeanProperty
   val additionalInputs: ConfigurableFileCollection = project.getObjects.fileCollection()
 
-  //noinspection DuplicatedCode
   @BeanProperty
   val imports: ConfigurableFileCollection = project.getObjects.fileCollection()
 
-  //noinspection DuplicatedCode
   @BeanProperty
   val searchPath: ConfigurableFileCollection = project.getObjects.fileCollection()
 
-  //noinspection DuplicatedCode
   @BeanProperty
   val topLevelArguments: MapProperty[String, Any] = project.getObjects.mapProperty(classOf[String], classOf[Any])
 
-  //noinspection DuplicatedCode
   @BeanProperty
   val externalVariables: MapProperty[String, Any] = project.getObjects.mapProperty(classOf[String], classOf[Any])
 
-  //noinspection DuplicatedCode
   @BeanProperty
   val indent: Property[Int] = project.getObjects.property(classOf[Int]).convention(-1)
+
+  // Properties that map onto Sjsonnet (interpreter) Settings
+  @BeanProperty
+  val preserveOrder: Property[Boolean] = project.getObjects.property(classOf[Boolean]).convention(false)
+
+  @BeanProperty
+  val strict: Property[Boolean] = project.getObjects.property(classOf[Boolean]).convention(false)
+
+  @BeanProperty
+  val noStaticErrors: Property[Boolean] = project.getObjects.property(classOf[Boolean]).convention(false)
+
+  @BeanProperty
+  val noDuplicateKeysInComprehension: Property[Boolean] = project.getObjects.property(classOf[Boolean]).convention(false)
+
+  @BeanProperty
+  val strictImportSyntax: Property[Boolean] = project.getObjects.property(classOf[Boolean]).convention(false)
+
+  @BeanProperty
+  val strictInheritedAssertions: Property[Boolean] = project.getObjects.property(classOf[Boolean]).convention(false)
 
   {
     project.sourceSets.flatMap(ss => Option(ss.findByName(name))).foreach { sourceSet =>


### PR DESCRIPTION
 - preserveOrder
 - strict
 - noStaticErrors
 - noDuplicateKeysInComprehension
 - strictImportSyntax
 - strictInheritedAssertions

Previously supported but not documented:
 - topLevelArguments
 - externalVariables
 - imports
 - searchPath